### PR TITLE
fix "GPU HANG" errors on Jasper Lake

### DIFF
--- a/drivers/gpu/drm/i915/gt/intel_engine_cs.c
+++ b/drivers/gpu/drm/i915/gt/intel_engine_cs.c
@@ -551,7 +551,7 @@ static int intel_engine_setup(struct intel_gt *gt, enum intel_engine_id id,
 		engine->flags |= I915_ENGINE_HAS_EU_PRIORITY;
 
 		/* EU attention is not available on VFs */
-		if(!IS_SRIOV_VF(gt->i915))
+		if(!IS_PLATFORM(i915, INTEL_JASPERLAKE) && !IS_SRIOV_VF(gt->i915))
 			engine->flags |= I915_ENGINE_HAS_EU_ATTENTION;
 
 		/* we only care about run alone on platforms that have a CCS */


### PR DESCRIPTION
修改为仅对Jasper Lake生效，不影响其他系列的核显