### PR TITLE
Fixing Errors & Warnings on JasperLake VM

### DIFF
--- a/drivers/gpu/drm/i915/gt/intel_engine_cs.c
+++ b/drivers/gpu/drm/i915/gt/intel_engine_cs.c
@@ -551,7 +551,7 @@ static int intel_engine_setup(struct intel_gt *gt, enum intel_engine_id id,
 		engine->flags |= I915_ENGINE_HAS_EU_PRIORITY;
 
 		/* EU attention is not available on VFs */
-		if(!IS_PLATFORM(i915, INTEL_JASPERLAKE) && !IS_SRIOV_VF(gt->i915))
+		if(!IS_SRIOV_VF(gt->i915))
 			engine->flags |= I915_ENGINE_HAS_EU_ATTENTION;
 
 		/* we only care about run alone on platforms that have a CCS */

--- a/drivers/gpu/drm/i915/i915_pci.c
+++ b/drivers/gpu/drm/i915/i915_pci.c
@@ -911,6 +911,9 @@ static const struct intel_device_info jsl_info = {
 	PLATFORM(INTEL_JASPERLAKE),
 	.platform_engine_mask = BIT(RCS0) | BIT(BCS0) | BIT(VCS0) | BIT(VECS0),
 	.ppgtt_size = 36,
+#ifdef CONFIG_SYNO_EPYC7002
+	.display = { 0 },
+#endif
 };
 
 #define GEN12_FEATURES \


### PR DESCRIPTION
1.原有的GPU HANG解决方案直接屏蔽了EU_ATTENTION，过于hack
2.在pass through情况下还是存在大量VBT warning

新的处理方案是针对性屏蔽了DSM下JasperLake的display，一次性解决了GPU HANG和VBT warning的问题，无副作用（群晖本身就不支持视频输出）